### PR TITLE
README: fix import path to the published package name (@bitjourney/react-from-html)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ builds an HTML snippet from a React element.
 
 ```tsx
 import React from "react";
-import { ReactFromHtml } from "react-from-html";
+import { ReactFromHtml } from "@bitjourney/react-from-html";
 
 const reactFromHtml = new ReactFromHtml();
 


### PR DESCRIPTION
README の SYNOPSIS が `import { ReactFromHtml } from "react-from-html"` になっていますが、無印の `react-from-html` は別のパッケージ（Measured Co.）で、この repo は `@bitjourney/react-from-html` として公開されています。README の通りに書くと別パッケージを import してしまうため、公開名に合わせて修正しました。